### PR TITLE
Updated air command to be more streamlined

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ $ asd issue-clone TP-43
 
 
 ### Air
+
+Runs air and appends arguments to `go test`, see: [Air Config](commands/air/.air.toml)
+
+
+- [ ] Add support for `--ignore-dirs` to ignore changes in certain directories
+
 ```bash
 # Livereload a test using air, see: https://github.com/cosmtrek/air
 # Note: be sure you have air installed `which air` => ~/go/bin/air
@@ -121,7 +127,11 @@ $ asd air
 
 # Matcher Live reload equivalent to `go test -v --run <some-test>
 $ asd air <some-test>
+
+# Live reload of all tests below a given directory equivalent to `go test -v ./...`
+$ asd air ./...
 ```
+
 
 ### Update
 

--- a/commands/air/.air.toml
+++ b/commands/air/.air.toml
@@ -4,7 +4,7 @@ tmp_dir = "tmp"
 [build]
   bin = "./tmp/air-main"
   cmd = "go test -v"
-  delay = 1
+  delay = 0
   exclude_dir = ["assets", "tmp", "vendor"]
   exclude_file = []
   exclude_regex = []

--- a/commands/air/command.go
+++ b/commands/air/command.go
@@ -1,7 +1,6 @@
 package air
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -23,24 +22,20 @@ func Command() *cli.Command {
 }
 
 func command(ctx *runtime.Context) (err error) {
-	var specificTest string
-	osArgs := ctx.Args().Slice()
-	if len(osArgs) > 0 {
-		if len(osArgs) > 1 {
-			return fmt.Errorf("Got args %v, only expected one, ex: `asd air <TestToRun>`", osArgs)
-		}
-		specificTest = osArgs[0]
-	}
-
 	config := &airConfig{}
 	err = toml.Unmarshal(EmptyAirToml, config)
 	if err != nil {
 		return
 	}
 
+	argsSlice := ctx.Args().Slice()
 	args := strings.Split(config.Build.Cmd, " ")
-	if len(specificTest) > 0 {
-		args = append(args, []string{"--run", specificTest}...)
+	if len(argsSlice) > 0 {
+		if strings.HasPrefix(argsSlice[0], "-") == true {
+			args = append(args, argsSlice...)
+		} else {
+			args = append(args, append([]string{"--run"}, argsSlice...)...)
+		}
 	}
 
 	config.Build.Cmd = strings.Join(args, " ")

--- a/commands/work/update.go
+++ b/commands/work/update.go
@@ -80,9 +80,13 @@ func update(filePath string) runtime.ActionFunc {
 		}
 
 		if ctx.Bool("no-git") == false {
-			err = ctx.ExecuteInDir(absPath, "git", "checkout", "master")
+			// TODO checkout HEAD?
+			err = ctx.ExecuteInDir(absPath, "git", "checkout", "main")
 			if err != nil {
-				return err
+				err = ctx.ExecuteInDir(absPath, "git", "checkout", "master")
+				if err != nil {
+					return err
+				}
 			}
 
 			err = ctx.ExecuteInDir(absPath, "git", "pull")


### PR DESCRIPTION
Here I made the following changes to the `asd air` command functionality:
- Removed build delay
- Added handling of extra arguments in command
- Updated README for change and added a TODO
- also made an unrelated change for checking out master or main