### PR TITLE
Only warn on GoWork add and remove

### DIFF
--- a/commands/work/add.go
+++ b/commands/work/add.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/pterm/pterm"
 	"github.com/taubyte/office-space/runtime"
 	. "github.com/taubyte/office-space/singletons"
 )
@@ -29,7 +30,7 @@ func add(ctx *runtime.Context) error {
 	// Add to go.work
 	err := GoWork().AddUse(dir)
 	if err != nil {
-		return fmt.Errorf("Adding relative `%s` to go.work failed with: %s", dir, err)
+		pterm.Warning.Printfln("Adding relative `%s` to go.work failed with: %s", dir, err)
 	}
 
 	// Add it to vs workspace

--- a/commands/work/clean_test.go
+++ b/commands/work/clean_test.go
@@ -24,7 +24,9 @@ func TestClean(t *testing.T) {
 	ctx.Run("work")
 	ctx.Run("work", "clean")
 
+	// TODO, streamline with users current go version
 	expectedGoWorkFile := "go 1.19\n"
+	expectedGoWorkFile20 := "go 1.20\n"
 
 	data, err := os.ReadFile(ctx.Dir + "/go.work")
 	if err != nil {
@@ -32,8 +34,9 @@ func TestClean(t *testing.T) {
 		return
 	}
 
-	if string(data) != expectedGoWorkFile {
-		t.Errorf("\nExpected \n%s, \ngot \n%s", expectedGoWorkFile, string(data))
+	if string(data) == expectedGoWorkFile || string(data) == expectedGoWorkFile20 {
 		return
+	} else {
+		t.Errorf("\nExpected \n%s, \ngot \n%s", expectedGoWorkFile, string(data))
 	}
 }

--- a/commands/work/remove.go
+++ b/commands/work/remove.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/pterm/pterm"
 	"github.com/taubyte/office-space/runtime"
 	. "github.com/taubyte/office-space/singletons"
 )
@@ -29,7 +30,7 @@ func remove(ctx *runtime.Context) error {
 	// Remove from go.work
 	err := GoWork().RemoveUse(dir)
 	if err != nil {
-		return fmt.Errorf("Removing Relative dir `%s` from go.work failed with: %s", dir, err)
+		pterm.Warning.Printfln("Removing Relative dir `%s` from go.work failed with: %s", dir, err)
 	}
 
 	// Remove from vs workspace


### PR DESCRIPTION
Here I fixed #14 where adding or removing a non-go repository would fail.  I also fixed clean_test for go1.20. 

Tests passing: https://asciinema.org/a/hKm37LFrWtG0IwMAMP7cs6cgY